### PR TITLE
fix: content not refreshing upon navigation

### DIFF
--- a/pages/[uid].vue
+++ b/pages/[uid].vue
@@ -3,7 +3,7 @@ import { components } from '~/slices'
 
 const prismic = usePrismic()
 const route = useRoute()
-const { data: page } = useAsyncData('[uid]', () =>
+const { data: page } = useAsyncData(route.params.uid, () =>
   prismic.client.getByUID('page', route.params.uid as string || 'home')
 )
 const settings = useSettings()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to starter maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Similar to https://github.com/prismicio-community/nuxt-starter-prismic-blog/pull/46

Fixes the navigation issue reported in https://github.com/prismicio/slice-machine/issues/1104:
- Open the demo site https://nuxt-starter-prismic-multi-page.vercel.app
- Click on the `About` menu link
- Click on the `More Info` menu link
- Problem: The content of `More info` is not displayed, the content of `About` is still displayed.

**Solution**: use the [key parameter](https://nuxt.com/docs/api/composables/use-async-data#params) on `useAsyncData` to make sure the request is unique to the content fetched. 


## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
